### PR TITLE
Adela/publicfeed

### DIFF
--- a/src/main/java/com/google/codeu/data/Datastore.java
+++ b/src/main/java/com/google/codeu/data/Datastore.java
@@ -79,4 +79,31 @@ public class Datastore {
 
     return messages;
   }
+
+  public List<Message> getAllMessages(){
+  List<Message> messages = new ArrayList<>();
+
+  Query query = new Query("Message")
+    .addSort("timestamp", SortDirection.DESCENDING);
+  PreparedQuery results = datastore.prepare(query);
+
+  for (Entity entity : results.asIterable()) {
+   try {
+    String idString = entity.getKey().getName();
+    UUID id = UUID.fromString(idString);
+    String user = (String) entity.getProperty("user");
+    String text = (String) entity.getProperty("text");
+    long timestamp = (long) entity.getProperty("timestamp");
+
+    Message message = new Message(id, user, text, timestamp);
+    messages.add(message);
+   } catch (Exception e) {
+    System.err.println("Error reading message.");
+    System.err.println(entity.toString());
+    e.printStackTrace();
+   }
+  }
+
+  return messages;
+ }
 }

--- a/src/main/java/com/google/codeu/servlets/MessageFeedServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageFeedServlet.java
@@ -1,0 +1,22 @@
+package com.google.codeu.servlets;
+
+import java.io.IOException;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Handles fetching all messages for the public feed.
+ */
+@WebServlet("/feed")
+public class MessageFeedServlet extends HttpServlet {
+  
+ @Override
+ public void doGet(HttpServletRequest request, HttpServletResponse response)
+   throws IOException {
+  
+  response.getOutputStream().println("this will be my message feed");
+ }
+}

--- a/src/main/java/com/google/codeu/servlets/MessageFeedServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageFeedServlet.java
@@ -1,22 +1,43 @@
 package com.google.codeu.servlets;
 
 import java.io.IOException;
+import java.util.List;
 
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.codeu.data.Datastore;
+import com.google.codeu.data.Message;
+import com.google.gson.Gson;
+
 /**
  * Handles fetching all messages for the public feed.
  */
 @WebServlet("/feed")
-public class MessageFeedServlet extends HttpServlet {
+public class MessageFeedServlet extends HttpServlet{
   
+ private Datastore datastore;
+
+ @Override
+ public void init() {
+  datastore = new Datastore();
+ }
+ 
+ /**
+  * Responds with a JSON representation of Message data for all users.
+  */
  @Override
  public void doGet(HttpServletRequest request, HttpServletResponse response)
    throws IOException {
+
+  response.setContentType("application/json");
   
-  response.getOutputStream().println("this will be my message feed");
+  List<Message> messages = datastore.getAllMessages();
+  Gson gson = new Gson();
+  String json = gson.toJson(messages);
+  
+  response.getOutputStream().println(json);
  }
 }


### PR DESCRIPTION
Following the instructions on Week2: Public Feed, I added a new servlet class "MessageFeedServlet", and I added a new method to Datastore "getAllMessages". The dummy page for feed is now accessible from http://localhost:8080/feed.